### PR TITLE
chore(deps): update GitHub Actions on 5.x

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -19,7 +19,7 @@ jobs:
     if: "!contains(github.event.head_commit.message, 'ci skip')"
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
       - name: Copy maven settings
@@ -30,7 +30,7 @@ jobs:
           java-version: 21.0.5+11
           distribution: liberica
       - name: Cache Maven dependencies
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/.m2/repository
           key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}


### PR DESCRIPTION
## Summary
Backports the open Renovate GitHub Actions updates from `master` to the `5.x` legacy branch, since Renovate is currently only producing GHA PRs against `master`.

- `actions/checkout` v4 → v6 (mirrors #216)
- `actions/cache` v4 → v5 (mirrors #208)

No open Renovate PRs exist for `entur/gha-maven-central` or `actions/setup-java`, so they are unchanged.

Commit is tagged `[skip ci]` per request.

## Test plan
- [ ] Workflow YAML parses (GitHub Actions validation on the PR)
- [ ] Next push to `5.x` (post-merge) uses the new action versions without regression