### PR TITLE
chore(deps): combined Renovate updates (master)

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Copy maven settings
         run: |
           wget https://raw.githubusercontent.com/entur/ror-maven-settings/master/.m2/settings.xml -O .github/workflows/settings.xml
-      - uses: actions/setup-java@v4
+      - uses: actions/setup-java@v5
         with:
           java-version: 21.0.5+11
           distribution: liberica

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -19,7 +19,7 @@ jobs:
     if: "!contains(github.event.head_commit.message, 'ci skip')"
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
       - name: Copy maven settings

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -30,7 +30,7 @@ jobs:
           java-version: 21.0.5+11
           distribution: liberica
       - name: Cache Maven dependencies
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/.m2/repository
           key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}

--- a/pom.xml
+++ b/pom.xml
@@ -51,7 +51,7 @@
 
         <nexus-staging-maven-plugin.version>1.7.0</nexus-staging-maven-plugin.version>
         <maven-scm-api.version>1.12.2</maven-scm-api.version>
-        <maven-scm-provider-gitexe.version>1.12.2</maven-scm-provider-gitexe.version>
+        <maven-scm-provider-gitexe.version>2.2.1</maven-scm-provider-gitexe.version>
         <owasp-dependency-check-plugin.version>12.1.3</owasp-dependency-check-plugin.version>
         <maven-gpg-plugin.version>1.6</maven-gpg-plugin.version>
         <gitflow-maven-plugin.version>1.21.0</gitflow-maven-plugin.version>

--- a/pom.xml
+++ b/pom.xml
@@ -50,7 +50,7 @@
         <google-pubsub-emulator.version>0.1.2</google-pubsub-emulator.version>
 
         <nexus-staging-maven-plugin.version>1.7.0</nexus-staging-maven-plugin.version>
-        <maven-scm-api.version>1.12.2</maven-scm-api.version>
+        <maven-scm-api.version>2.2.1</maven-scm-api.version>
         <maven-scm-provider-gitexe.version>1.12.2</maven-scm-provider-gitexe.version>
         <owasp-dependency-check-plugin.version>12.1.3</owasp-dependency-check-plugin.version>
         <maven-gpg-plugin.version>1.6</maven-gpg-plugin.version>

--- a/pom.xml
+++ b/pom.xml
@@ -45,7 +45,7 @@
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 
         <jacoco-maven-plugin.version>0.8.13</jacoco-maven-plugin.version>
-        <sonar-maven-plugin.version>5.1.0.4751</sonar-maven-plugin.version>
+        <sonar-maven-plugin.version>5.6.0.6792</sonar-maven-plugin.version>
 
         <google-pubsub-emulator.version>0.1.2</google-pubsub-emulator.version>
 

--- a/pom.xml
+++ b/pom.xml
@@ -56,7 +56,7 @@
         <maven-gpg-plugin.version>1.6</maven-gpg-plugin.version>
         <gitflow-maven-plugin.version>1.21.0</gitflow-maven-plugin.version>
         <jreleaser-maven-plugin.version>1.19.0</jreleaser-maven-plugin.version>
-        <logstash.version>8.1</logstash.version>
+        <logstash.version>9.0</logstash.version>
         <google.cloud.bom-version>26.66.0</google.cloud.bom-version>
 
         <!-- Downloading PubSub emulator is disabled by default-->

--- a/pom.xml
+++ b/pom.xml
@@ -55,7 +55,7 @@
         <owasp-dependency-check-plugin.version>12.1.3</owasp-dependency-check-plugin.version>
         <maven-gpg-plugin.version>1.6</maven-gpg-plugin.version>
         <gitflow-maven-plugin.version>1.21.0</gitflow-maven-plugin.version>
-        <jreleaser-maven-plugin.version>1.19.0</jreleaser-maven-plugin.version>
+        <jreleaser-maven-plugin.version>1.23.0</jreleaser-maven-plugin.version>
         <logstash.version>8.1</logstash.version>
         <google.cloud.bom-version>26.66.0</google.cloud.bom-version>
 

--- a/pom.xml
+++ b/pom.xml
@@ -52,7 +52,7 @@
         <nexus-staging-maven-plugin.version>1.7.0</nexus-staging-maven-plugin.version>
         <maven-scm-api.version>1.12.2</maven-scm-api.version>
         <maven-scm-provider-gitexe.version>1.12.2</maven-scm-provider-gitexe.version>
-        <owasp-dependency-check-plugin.version>12.1.3</owasp-dependency-check-plugin.version>
+        <owasp-dependency-check-plugin.version>12.2.1</owasp-dependency-check-plugin.version>
         <maven-gpg-plugin.version>1.6</maven-gpg-plugin.version>
         <gitflow-maven-plugin.version>1.21.0</gitflow-maven-plugin.version>
         <jreleaser-maven-plugin.version>1.19.0</jreleaser-maven-plugin.version>

--- a/pom.xml
+++ b/pom.xml
@@ -57,7 +57,7 @@
         <gitflow-maven-plugin.version>1.21.0</gitflow-maven-plugin.version>
         <jreleaser-maven-plugin.version>1.19.0</jreleaser-maven-plugin.version>
         <logstash.version>8.1</logstash.version>
-        <google.cloud.bom-version>26.66.0</google.cloud.bom-version>
+        <google.cloud.bom-version>26.80.0</google.cloud.bom-version>
 
         <!-- Downloading PubSub emulator is disabled by default-->
         <entur.google.pubsub.emulator.download.skip>true</entur.google.pubsub.emulator.download.skip>

--- a/pom.xml
+++ b/pom.xml
@@ -44,7 +44,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 
-        <jacoco-maven-plugin.version>0.8.13</jacoco-maven-plugin.version>
+        <jacoco-maven-plugin.version>0.8.14</jacoco-maven-plugin.version>
         <sonar-maven-plugin.version>5.1.0.4751</sonar-maven-plugin.version>
 
         <google-pubsub-emulator.version>0.1.2</google-pubsub-emulator.version>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>4.0.4</version>
+        <version>4.0.5</version>
     </parent>
 
     <groupId>org.entur.ror</groupId>


### PR DESCRIPTION
## Summary

Combines all open Renovate PRs against `master` into a single PR. Where multiple PRs targeted the same dependency, the highest version was kept.

### Dependency updates (pom.xml)
- `spring-boot-starter-parent`: 4.0.4 → 4.0.5 (#219)
- `net.logstash.logback:logstash-logback-encoder`: 8.1 → 9.0 (#223, major)
- `com.google.cloud:libraries-bom`: 26.66.0 → 26.80.0 (#215)
- `org.apache.maven.scm:maven-scm-api`: 1.12.2 → 2.2.1 (#221, major — supersedes #211)
- `org.apache.maven.scm:maven-scm-provider-gitexe`: 1.12.2 → 2.2.1 (#222, major — supersedes #212)
- `org.owasp:dependency-check-maven`: 12.1.3 → 12.2.1 (#207 — supersedes #210)
- `org.sonarsource.scanner.maven:sonar-maven-plugin`: 5.1.0.4751 → 5.6.0.6792 (#214)
- `org.jreleaser:jreleaser-maven-plugin`: 1.19.0 → 1.23.0 (#213)
- `org.jacoco:jacoco-maven-plugin`: 0.8.13 → 0.8.14 (#209)

### GitHub Actions updates (.github/workflows/push.yml)
- `actions/checkout`: v4 → v6 (#216)
- `actions/setup-java`: v4 → v5 (#220)
- `actions/cache`: v4 → v5 (#208)

### Superseded (not merged — covered by newer versions above)
- #210 `dependency-check-maven` → v12.1.9 (superseded by v12.2.1 in #207)
- #211 `maven-scm-api` → v1.13.0 (superseded by v2.2.1 in #221)
- #212 `maven-scm-provider-gitexe` → v1.13.0 (superseded by v2.2.1 in #222)
