### PR TITLE
chore(deps): combined Renovate updates (5.x, minor/patch only)

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Copy maven settings
         run: |
           wget https://raw.githubusercontent.com/entur/ror-maven-settings/master/.m2/settings.xml -O .github/workflows/settings.xml
-      - uses: actions/setup-java@v4
+      - uses: actions/setup-java@v5
         with:
           java-version: 21.0.5+11
           distribution: liberica

--- a/pom.xml
+++ b/pom.xml
@@ -50,7 +50,7 @@
         <google-pubsub-emulator.version>0.1.2</google-pubsub-emulator.version>
 
         <nexus-staging-maven-plugin.version>1.7.0</nexus-staging-maven-plugin.version>
-        <maven-scm-api.version>1.12.2</maven-scm-api.version>
+        <maven-scm-api.version>1.13.0</maven-scm-api.version>
         <maven-scm-provider-gitexe.version>1.12.2</maven-scm-provider-gitexe.version>
         <owasp-dependency-check-plugin.version>12.1.3</owasp-dependency-check-plugin.version>
         <maven-gpg-plugin.version>1.6</maven-gpg-plugin.version>

--- a/pom.xml
+++ b/pom.xml
@@ -51,7 +51,7 @@
 
         <nexus-staging-maven-plugin.version>1.7.0</nexus-staging-maven-plugin.version>
         <maven-scm-api.version>1.12.2</maven-scm-api.version>
-        <maven-scm-provider-gitexe.version>1.12.2</maven-scm-provider-gitexe.version>
+        <maven-scm-provider-gitexe.version>1.13.0</maven-scm-provider-gitexe.version>
         <owasp-dependency-check-plugin.version>12.1.3</owasp-dependency-check-plugin.version>
         <maven-gpg-plugin.version>1.6</maven-gpg-plugin.version>
         <gitflow-maven-plugin.version>1.21.0</gitflow-maven-plugin.version>

--- a/pom.xml
+++ b/pom.xml
@@ -45,7 +45,7 @@
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 
         <jacoco-maven-plugin.version>0.8.13</jacoco-maven-plugin.version>
-        <sonar-maven-plugin.version>5.1.0.4751</sonar-maven-plugin.version>
+        <sonar-maven-plugin.version>5.6.0.6792</sonar-maven-plugin.version>
 
         <google-pubsub-emulator.version>0.1.2</google-pubsub-emulator.version>
 

--- a/pom.xml
+++ b/pom.xml
@@ -55,7 +55,7 @@
         <owasp-dependency-check-plugin.version>12.1.3</owasp-dependency-check-plugin.version>
         <maven-gpg-plugin.version>1.6</maven-gpg-plugin.version>
         <gitflow-maven-plugin.version>1.21.0</gitflow-maven-plugin.version>
-        <jreleaser-maven-plugin.version>1.19.0</jreleaser-maven-plugin.version>
+        <jreleaser-maven-plugin.version>1.23.0</jreleaser-maven-plugin.version>
         <logstash.version>8.1</logstash.version>
         <google.cloud.bom-version>26.66.0</google.cloud.bom-version>
 

--- a/pom.xml
+++ b/pom.xml
@@ -52,7 +52,7 @@
         <nexus-staging-maven-plugin.version>1.7.0</nexus-staging-maven-plugin.version>
         <maven-scm-api.version>1.12.2</maven-scm-api.version>
         <maven-scm-provider-gitexe.version>1.12.2</maven-scm-provider-gitexe.version>
-        <owasp-dependency-check-plugin.version>12.1.3</owasp-dependency-check-plugin.version>
+        <owasp-dependency-check-plugin.version>12.2.1</owasp-dependency-check-plugin.version>
         <maven-gpg-plugin.version>1.6</maven-gpg-plugin.version>
         <gitflow-maven-plugin.version>1.21.0</gitflow-maven-plugin.version>
         <jreleaser-maven-plugin.version>1.19.0</jreleaser-maven-plugin.version>

--- a/pom.xml
+++ b/pom.xml
@@ -57,7 +57,7 @@
         <gitflow-maven-plugin.version>1.21.0</gitflow-maven-plugin.version>
         <jreleaser-maven-plugin.version>1.19.0</jreleaser-maven-plugin.version>
         <logstash.version>8.1</logstash.version>
-        <google.cloud.bom-version>26.66.0</google.cloud.bom-version>
+        <google.cloud.bom-version>26.80.0</google.cloud.bom-version>
 
         <!-- Downloading PubSub emulator is disabled by default-->
         <entur.google.pubsub.emulator.download.skip>true</entur.google.pubsub.emulator.download.skip>

--- a/pom.xml
+++ b/pom.xml
@@ -44,7 +44,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 
-        <jacoco-maven-plugin.version>0.8.13</jacoco-maven-plugin.version>
+        <jacoco-maven-plugin.version>0.8.14</jacoco-maven-plugin.version>
         <sonar-maven-plugin.version>5.1.0.4751</sonar-maven-plugin.version>
 
         <google-pubsub-emulator.version>0.1.2</google-pubsub-emulator.version>


### PR DESCRIPTION
## Summary

Combines open Renovate PRs against `5.x` into a single PR. Scope: **minor and patch updates only**, with the exception of #232 (actions/setup-java v4 → v5), which is included at the user's request. Other major updates are excluded and left as standalone PRs.

### Dependency updates (pom.xml)
- `com.google.cloud:libraries-bom`: 26.66.0 → 26.80.0 (#231, minor)
- `org.sonarsource.scanner.maven:sonar-maven-plugin`: 5.1.0.4751 → 5.6.0.6792 (#230, minor)
- `org.owasp:dependency-check-maven`: 12.1.3 → 12.2.1 (#229, minor — supersedes patch #225)
- `org.jreleaser:jreleaser-maven-plugin`: 1.19.0 → 1.23.0 (#228, minor)
- `org.apache.maven.scm:maven-scm-provider-gitexe`: 1.12.2 → 1.13.0 (#227, minor)
- `org.apache.maven.scm:maven-scm-api`: 1.12.2 → 1.13.0 (#226, minor)
- `org.jacoco:jacoco-maven-plugin`: 0.8.13 → 0.8.14 (#224, patch)

### GitHub Actions updates (.github/workflows/push.yml)
- `actions/setup-java`: v4 → v5 (#232, major — included at user's request)

### Superseded (not merged — covered by newer versions above)
- #225 `dependency-check-maven` → v12.1.9 (patch, superseded by v12.2.1 in #229)

