### PR TITLE
Fix Sonar scan: pin sude dependency for sonar-maven-plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -266,6 +266,19 @@
                 <groupId>org.sonarsource.scanner.maven</groupId>
                 <artifactId>sonar-maven-plugin</artifactId>
                 <version>${sonar-maven-plugin.version}</version>
+                <dependencies>
+                    <!-- sonar-scanner-java-library -> ayza -> sude, but ayza declares `sude`
+                         without a version (it is managed only in ayza-parent), so the version
+                         is not applied in the plugin classpath realm and sude is dropped,
+                         causing ClassNotFoundException: nl.altindag.sude.LoggerFactory when the
+                         scanner initialises its HTTPS client. Pin it explicitly until SonarSource
+                         fixes the scanner dependency chain (still broken in scanner-maven 5.7.0). -->
+                    <dependency>
+                        <groupId>io.github.hakky54</groupId>
+                        <artifactId>sude</artifactId>
+                        <version>2.0.2</version>
+                    </dependency>
+                </dependencies>
             </plugin>
 
             <plugin>


### PR DESCRIPTION
## Problem

The Sonar scan step fails for projects on superpom 6.4.x with:

```
ClassNotFoundException: nl.altindag.sude.LoggerFactory
```

## Root cause

Dependency chain of the scanner:

```
sonar-maven-plugin:5.6.0.6792
└─ sonar-scanner-java-library:4.1.1.1633
   └─ io.github.hakky54:ayza:10.0.3        ← SSL lib (ex sslcontext-kickstart)
      └─ io.github.hakky54:sude            ← logging facade (nl.altindag.sude.LoggerFactory)
```

`ayza` uses `sude` at runtime (the scanner touches it when initialising its HTTPS client), but `ayza-10.0.3.pom` declares its `sude` dependency **without a version** — the version (`2.0.2`) is managed only in `ayza-parent`. During plugin-classpath realm resolution that parent-managed version is not applied, so `sude` is silently dropped from the scanner classpath → `ClassNotFoundException`.

It is **not** a mirror-availability problem: CI logs show `ayza-10.0.3.jar` present on the classpath while `sude` is entirely absent (same groupId), i.e. Maven never resolved `sude` into the graph.

## Is it fixed upstream?

No. The latest `sonar-maven-plugin` (5.7.0.6970) still depends on the same `sonar-scanner-java-library:4.1.1.1633` → `ayza:10.0.3`, and the identical error is reported upstream against scanner-maven 5.7.0 and scanner-gradle 7.3.0. No SonarSource fix released yet.

- https://community.sonarsource.com/t/sonar-scanner-gradle-7-3-0-classnotfoundexception-nl-altindag-sude-loggerfactory/182633

## Fix

Pin `io.github.hakky54:sude:2.0.2` (the version `ayza-parent:10.0.3` expects) as an explicit dependency of the `sonar-maven-plugin` declaration. Doing it in the superpom fixes every consumer (baba, uttu, lamassu, …) at once. Remove once SonarSource corrects the scanner dependency chain.