### PR TITLE
Harmonize Renovate onto shared config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,22 +1,18 @@
 {
-  "extends": ["config:recommended"],
-  "baseBranchPatterns": [
-    "master",
-    "5.x"
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    "github>entur/ror-renovate-config"
   ],
+  "baseBranchPatterns": ["master", "5.x"],
   "separateMinorPatch": true,
   "packageRules": [
     {
-      "matchPackageNames": [
-        "org.springframework.boot:spring-boot-starter-parent"
-      ],
+      "matchPackageNames": ["org.springframework.boot:spring-boot-starter-parent"],
       "matchUpdateTypes": ["patch", "pin", "digest"],
       "automerge": true
     },
     {
-      "matchPackageNames": [
-        "org.springframework.boot:spring-boot-starter-parent"
-      ],
+      "matchPackageNames": ["org.springframework.boot:spring-boot-starter-parent"],
       "matchBaseBranches": ["5.x"],
       "allowedVersions": "<4.0.0"
     }


### PR DESCRIPTION
## Harmonize onto the shared Renovate config

Adds the team's shared preset `github>entur/ror-renovate-config` in place of the
bare `config:recommended`.

**Deliberately preserved** (repo-specific, not covered by the shared config):
- `baseBranchPatterns: [master, 5.x]` — superpom maintains a `5.x` branch in
  addition to the default, so this override is genuinely needed.
- `separateMinorPatch: true`.
- The `spring-boot-starter-parent` package rules (patch/pin/digest automerge, and
  the `<4.0.0` constraint on the `5.x` branch).



---
_Part of the team-wide Renovate harmonization. Depends on the shared-config update **entur/ror-renovate-config#12** (merge that first)._