### PR TITLE
Upgrade to Spring Boot 4.1 and Java 25

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -6,20 +6,19 @@ on:
   pull_request:
     branches:
       - master
-env:
-    JFROG_USER: ${{ secrets.ARTIFACTORY_AUTH_USER }}
-    JFROG_PASS: ${{ secrets.ARTIFACTORY_AUTH_TOKEN }}
-    SONATYPE_GPG_KEY_BASE64: ${{ secrets.SONATYPE_GPG_KEY_BASE64 }}
-    SONATYPE_USERNAME: ${{ secrets.SONATYPE_USERNAME }}
-    SONATYPE_PASSWORD: ${{ secrets.SONATYPE_PASSWORD }}
-    SONATYPE_GPG_KEY_PASSWORD: ${{ secrets.SONATYPE_GPG_KEY_PASSWORD }}
-    NVD_API_KEY: ${{ secrets.NVD_API_KEY }}
 jobs:
   maven-package:
     if: "!contains(github.event.head_commit.message, 'ci skip')"
     runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+    # Only what the downloaded settings.xml actually references. The signing key and
+    # Artifactory credentials belong to publish-release, which gets them via secrets: inherit.
+    env:
+      SONATYPE_USERNAME: ${{ secrets.SONATYPE_USERNAME }}
+      SONATYPE_PASSWORD: ${{ secrets.SONATYPE_PASSWORD }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0
       - name: Copy maven settings
@@ -27,10 +26,10 @@ jobs:
           wget https://raw.githubusercontent.com/entur/ror-maven-settings/master/.m2/settings_release_maven_central.xml -O .github/workflows/settings.xml
       - uses: actions/setup-java@v5
         with:
-          java-version: 21.0.5+11
+          java-version: 25
           distribution: liberica
       - name: Cache Maven dependencies
-        uses: actions/cache@v5
+        uses: actions/cache@v6
         with:
           path: ~/.m2/repository
           key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
@@ -48,6 +47,10 @@ jobs:
     uses: entur/gha-maven-central/.github/workflows/maven-publish.yml@v1
     secrets: inherit
     with:
+      # Must match java.version in pom.xml, or enforcer fails during the deploy step.
+      java_version: 25
       push_to_repo: true
       snapshot: false
-      next_version: 'minor'
+      # One-off: 'minor' would compute 7.1.0 from 7.0.0-SNAPSHOT and skip 7.0.0 entirely.
+      # Revert to 'minor' once 7.0.0 is released.
+      next_version: '7.0.0'

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,51 +1,124 @@
 # CLAUDE.md
 
-This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+Guidance for Claude Code (claude.ai/code) when working in this repository.
 
-## Project Overview
+## What this is
 
-Superpom is a Maven parent POM (`<packaging>pom</packaging>`) for Entur's routes and journey planning Java/Spring Boot microservices. It contains **no application source code** — only build configuration, dependency management, and plugin management that child projects inherit.
+Superpom is a Maven parent POM (`<packaging>pom</packaging>`) for Entur's routes and journey
+planning Java/Spring Boot services: `org.entur.ror:superpom`, parented to
+`spring-boot-starter-parent`, main branch `master`. There is no application source code, only
+dependency management, plugin management and build config that child projects inherit.
 
-- **Group ID:** `org.entur.ror`
-- **Parent:** `spring-boot-starter-parent` (Spring Boot 3.5.x)
-- **Java version:** 17 (enforced by maven-enforcer-plugin)
-- **Main branch:** `master`
+`pom.xml` is the whole deliverable. Read it rather than trusting a summary here, and do not
+copy its version numbers into this file where they will go stale.
 
-## Build Commands
+## Build
 
 ```bash
-# Build (validate POM, run enforcer checks)
-mvn package
-
-# Build with Entur settings (as CI does)
-mvn package -s .github/workflows/settings.xml
-
-# OWASP dependency vulnerability check (requires NVD_API_KEY)
-mvn dependency-check:check
+mvn package                  # POM validation, enforcer, plugin wiring
+mvn dependency-check:check   # OWASP scan, requires NVD_API_KEY
 ```
 
-## Key Configuration
+CI runs `mvn package -s .github/workflows/settings.xml`, but that settings file is not in the
+repo: `push.yml` downloads it from `entur/ror-maven-settings` at build time. Locally, use plain
+`mvn package`.
 
-### Dependency Management
-- Google Cloud BOM (`libraries-bom`)
-- Logstash Logback Encoder
+## What the POM manages
 
-### Plugin Management (inherited by child projects)
-- **Compiler:** Java 17 with `-Xlint:all`
-- **Surefire:** Sets `env=dev` system property for tests
-- **Failsafe:** Integration test execution bound to `verify`
-- **JaCoCo:** Code coverage reporting
-- **OWASP Dependency-Check:** Fails build on CVSS >= 7; suppression file: `dependencycheck-suppression.xml`
-- **JReleaser:** Publishes to Maven Central via Sonatype
-- **Gitflow:** Development branch is `master`; commit messages prefixed with `[ci skip]`
+Two things in `dependencyManagement`: the Google Cloud BOM (`libraries-bom`, import scope) and
+`logstash-logback-encoder`. Everything else comes from the Spring Boot parent.
 
-### Profiles
-- `publication` — Attaches sources and javadoc JARs, deploys to local staging directory for JReleaser
+The distinction between the two plugin blocks matters, and is the opposite of what "parent POM"
+suggests:
 
-## Release Process
+- `build/plugins` is inherited by every child, but only the entries carrying `<executions>`
+  actually run in its lifecycle: enforcer (Java version, `requirePluginVersions` at WARN),
+  surefire, jacoco (agent, report, check), failsafe (`integration-test` + `verify`), source.
+- Also in `build/plugins` but declared with no `<executions>`, so they run only when invoked
+  explicitly: sonar (`mvn sonar:sonar`), javadoc, gitflow (`mvn gitflow:release-start`;
+  `developmentBranch` = `master`, commits prefixed `[ci skip]`). Editing these three does not
+  change any consumer's build.
+- `pluginManagement` supplies config only when the plugin actually runs: compiler
+  (`-Xlint:all`, forked, `-J-Xss4m`), surefire (`env=dev`), javadoc, release, jreleaser, OWASP
+  dependency-check. For compiler and surefire that happens via default lifecycle bindings, so
+  the config does reach children. OWASP has no `<execution>` declared anywhere, so despite the
+  CVSS threshold being configured here the scan never runs by inheritance: it needs
+  `mvn dependency-check:check`, or an execution added in the child. Adding a `<phase>` here
+  will not help.
 
-Releases are automated via GitHub Actions (`push.yml`). On push to `master`, the CI builds and then publishes to Maven Central using the reusable `entur/gha-maven-central` workflow with `next_version: 'minor'`. Version bumps in commit messages contain `[skip ci]` / `ci skip` to avoid recursive builds.
+## Things that are easy to get wrong
 
-## Dependency Updates
+**Every change ships to every consumer** (baba, uttu, lamassu, ...). Nothing here compiles
+Java, so a green `mvn package` proves very little. Validate plugin and BOM bumps by forcing
+real resolution, e.g. `mvn dependency:resolve-plugins` or `mvn <prefix>:help`, instead of
+assuming a version that exists also works.
 
-Managed by Renovate (`renovate.json`). Spring Boot starter patch/digest updates are auto-merged.
+**`java.version` gates every JDK in the pipeline.** It feeds `maven-compiler-plugin`'s
+`<release>`, the javadoc report in `<reporting>`, and the enforcer's `requireJavaVersion`, where
+a bare value means that version *or higher* (`25` becomes `[25,)`). That floor binds consumers
+too: adopting a new major means their local and CI JDKs must meet it, unless they set their own
+`<java.version>`, which does override it cleanly and is the escape hatch to tell them about.
+
+**Two JDKs need bumping, not one.** `java-version` in the `maven-package` job of
+`.github/workflows/push.yml`, *and* the `java_version` input to `publish-release`, which
+defaults to 21 in `entur/gha-maven-central`. Miss the second and the build goes green, then the
+release dies at the enforcer during `mvn -Ppublication deploy`.
+
+**Never test a Java bump with `-Djava.version=N`.** The name collides with the JVM's own
+`java.version` system property, so `-D` sets the enforcer's requirement *and* the detected JDK
+version to the same value: the rule passes vacuously and you get a false green. With the rule
+hardcoded to `[25,26)`, `-Djava.version=99` reports "Detected JDK ... is version 99". Edit the
+property in a scratch copy of the POM instead. Relatedly, `help:evaluate` reports the JVM's
+value here, not the POM's.
+
+**The released version is computed, not read from the POM.** A push to `master` runs
+`entur/gha-maven-central` with `next_version: 'minor'`, which takes the POM's current version
+and increments the *minor*, zeroing the patch. There is no manual release step. Hand-setting
+`7.0.0-SNAPSHOT` therefore does not ship 7.0.0, it ships **7.1.0**; history confirms it, since
+`6.0.0-SNAPSHOT` went out as `6.1.0` and Central has no 6.0.0 at all. To ship an exact version,
+pass it for that run as `next_version: '7.0.0'`.
+
+Commits containing `[skip ci]` are suppressed by GitHub's own native skip handling, not by the
+`if:` guard in `push.yml`, which only matches the substring `ci skip`.
+
+**`5.x` is a live maintenance line** for consumers still on Spring Boot 3.5 / Java 17, tracked
+by Renovate and pinned to Spring Boot `<4.0.0` in `renovate.json`. Consumer-facing fixes may
+need backporting. (`1.x` exists but has been dormant since 2023.)
+
+**`dependencycheck-suppression.xml` is not in this repo.** The OWASP config names it as a
+relative path, so it resolves in each child project. Adding it here will not apply downstream.
+
+**The `sude` pin on `sonar-maven-plugin` is unproven, not verified-necessary.** The POM comment
+explains the original `ClassNotFoundException` and its premises still hold, but the failure does
+not reproduce here: sude 2.0.2 lands on the plugin classpath with *and* without the pin.
+Superpom's own CI never runs Sonar, so it was only ever seen in a consumer. Reproduce it in a
+consumer before removing the pin.
+
+**`protobuf-java.version` and `grpc-java.version` must be re-checked on every
+`google.cloud.bom-version` bump.** Spring Boot manages protobuf and grpc through *imported*
+BOMs, which lose to superpom's imported `libraries-bom`, but it drives `protoc` and
+`protoc-gen-grpc-java` from those two plain properties. If they drift from what libraries-bom
+resolves, codegen and runtime diverge and proto classes throw
+`ProtobufRuntimeVersionException: Detected incompatible Protobuf Gencode/Runtime versions`
+on first load, *after* a completely green build. Renovate cannot catch this, since the
+properties have no dependency attached. After bumping the BOM, confirm the pins still match:
+
+```bash
+mvn dependency:list        # in a child: what protobuf-java/grpc-core actually resolve to
+mvn help:effective-pom     # in a child: grep <protoc> and compare
+```
+
+The general rule: Spring Boot's *direct* `dependencyManagement` entries win over superpom's
+imported `libraries-bom`; its *nested BOM imports* lose to it. Overlapping artifacts where the
+two disagree went from 1 to 36 when the parent moved to Spring Boot 4.1.
+
+**Two publish targets coexist.** `distributionManagement` points at `entur2.jfrog.io`
+Artifactory and `push.yml` exports `JFROG_*`, while the actual release path goes to Maven
+Central through JReleaser. Know which one you are touching.
+
+## Other
+
+- Profile `publication` attaches sources and javadoc JARs and deploys to
+  `target/staging-deploy` for JReleaser.
+- Dependency updates come from Renovate (`renovate.json`), which auto-merges Spring Boot
+  parent patch/pin/digest bumps.

--- a/pom.xml
+++ b/pom.xml
@@ -5,12 +5,12 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>4.0.6</version>
+        <version>4.1.0</version>
     </parent>
 
     <groupId>org.entur.ror</groupId>
     <artifactId>superpom</artifactId>
-    <version>6.5.1-SNAPSHOT</version>
+    <version>7.0.0-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <name>superpom</name>
@@ -40,28 +40,28 @@
 
     <properties>
 
-        <java.version>17</java.version>
+        <java.version>25</java.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 
-        <jacoco-maven-plugin.version>0.8.14</jacoco-maven-plugin.version>
-        <sonar-maven-plugin.version>5.6.0.6792</sonar-maven-plugin.version>
+        <jacoco-maven-plugin.version>0.8.15</jacoco-maven-plugin.version>
+        <sonar-maven-plugin.version>5.7.0.6970</sonar-maven-plugin.version>
 
-        <google-pubsub-emulator.version>0.1.2</google-pubsub-emulator.version>
-
-        <nexus-staging-maven-plugin.version>1.7.0</nexus-staging-maven-plugin.version>
         <maven-scm-api.version>2.2.1</maven-scm-api.version>
         <maven-scm-provider-gitexe.version>2.2.1</maven-scm-provider-gitexe.version>
-        <owasp-dependency-check-plugin.version>12.2.1</owasp-dependency-check-plugin.version>
-        <maven-gpg-plugin.version>1.6</maven-gpg-plugin.version>
+        <owasp-dependency-check-plugin.version>12.2.2</owasp-dependency-check-plugin.version>
         <gitflow-maven-plugin.version>1.21.0</gitflow-maven-plugin.version>
-        <jreleaser-maven-plugin.version>1.23.0</jreleaser-maven-plugin.version>
+        <jreleaser-maven-plugin.version>1.25.0</jreleaser-maven-plugin.version>
         <logstash.version>9.0</logstash.version>
-        <google.cloud.bom-version>26.80.0</google.cloud.bom-version>
+        <google.cloud.bom-version>26.86.0</google.cloud.bom-version>
 
-        <!-- Downloading PubSub emulator is disabled by default-->
-        <entur.google.pubsub.emulator.download.skip>true</entur.google.pubsub.emulator.download.skip>
-
+        <!-- Spring Boot manages protobuf/grpc via imported BOMs, which lose to libraries-bom,
+             but it drives protoc and protoc-gen-grpc-java from these plain properties. Left
+             alone, codegen and runtime diverge and proto classes fail to load at runtime with
+             "Detected incompatible Protobuf Gencode/Runtime versions". Keep these aligned with
+             what libraries-bom actually resolves. -->
+        <protobuf-java.version>4.33.6</protobuf-java.version>
+        <grpc-java.version>1.82.2</grpc-java.version>
 
     </properties>
 
@@ -150,7 +150,9 @@
                         <jreleaser>
                             <signing>
                                 <active>ALWAYS</active>
-                                <armored>true</armored>
+                                <pgp>
+                                    <armored>true</armored>
+                                </pgp>
                             </signing>
                             <deploy>
                                 <maven>
@@ -329,19 +331,10 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
                 <configuration>
-                    <!-- Trying to create doc java-11 only -->
-                    <javadocVersion>${java.version}</javadocVersion>
                     <minmemory>128m</minmemory>
                     <maxmemory>768m</maxmemory>
                     <breakiterator>true</breakiterator>
-                    <doclet>org.jboss.apiviz.APIviz</doclet>
-                    <docletArtifact>
-                        <groupId>org.jboss.apiviz</groupId>
-                        <artifactId>apiviz</artifactId>
-                        <version>1.3.2.GA</version>
-                    </docletArtifact>
                     <useStandardDocletOptions>true</useStandardDocletOptions>
-                    <breakiterator>true</breakiterator>
                     <version>true</version>
                     <author>true</author>
                     <keywords>true</keywords>


### PR DESCRIPTION
Java 25 is breaking for consumers: requireJavaVersion is a floor, so children need JDK 25 unless they set their own java.version.

Fix two release blockers the Java bump exposed:
- publish-release defaulted to JDK 21 and would fail the enforcer at deploy
- next_version 'minor' computes 7.1.0 from 7.0.0-SNAPSHOT, skipping 7.0.0. Revert it to 'minor' once 7.0.0 is out.

Pin protobuf-java and grpc-java to what libraries-bom resolves. Spring Boot drives protoc from those properties but manages the runtime through imported BOMs that lose to libraries-bom, so codegen and runtime diverged and proto classes failed to load after a green build.

Drop the APIviz doclet (invalid since JDK 13, fails mvn site) and the unreferenced maven-gpg-plugin and nexus-staging properties.