### PR TITLE
Move JFrog artifactory configuration to dedicated module

### DIFF
--- a/jfrog-artifactory/pom.xml
+++ b/jfrog-artifactory/pom.xml
@@ -1,0 +1,30 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.entur.ror</groupId>
+        <artifactId>superpom</artifactId>
+        <version>8.0.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>superpom-jfrog-artifactory</artifactId>
+    <packaging>pom</packaging>
+
+    <name>superpom-jfrog-artifactory</name>
+    <description>Configures deployment of superpom artifacts to Entur's Artifactory (JFrog) instance</description>
+
+    <distributionManagement>
+        <repository>
+            <id>central</id>
+            <name>entur2-releases</name>
+            <url>https://entur2.jfrog.io/entur2/libs-release-local</url>
+        </repository>
+        <snapshotRepository>
+            <id>snapshots</id>
+            <name>entur2-snapshots</name>
+            <url>https://entur2.jfrog.io/entur2/libs-snapshot-local</url>
+        </snapshotRepository>
+    </distributionManagement>
+
+</project>

--- a/pom.xml
+++ b/pom.xml
@@ -10,8 +10,12 @@
 
     <groupId>org.entur.ror</groupId>
     <artifactId>superpom</artifactId>
-    <version>7.0.1-SNAPSHOT</version>
+    <version>8.0.0-SNAPSHOT</version>
     <packaging>pom</packaging>
+
+    <modules>
+        <module>jfrog-artifactory</module>
+    </modules>
 
     <name>superpom</name>
     <description>Super pom for routes and journey planning components</description>
@@ -25,19 +29,6 @@
         <developerConnection>scm:git:ssh://git@github.com/entur/superpom.git</developerConnection>
       <tag>HEAD</tag>
     </scm>
-    <distributionManagement>
-        <repository>
-            <id>central</id>
-            <name>entur2-releases</name>
-            <url>https://entur2.jfrog.io/entur2/libs-release-local</url>
-        </repository>
-        <snapshotRepository>
-            <id>snapshots</id>
-            <name>entur2-snapshots</name>
-            <url>https://entur2.jfrog.io/entur2/libs-snapshot-local</url>
-        </snapshotRepository>
-    </distributionManagement>
-
     <properties>
 
         <java.version>25</java.version>


### PR DESCRIPTION
Split jfrog artifactory support into dedicated pom. Avoid using artifactory secrets in public repos.

Public repos: `org.entur.ror:superpom`
Private repos: `org.entur.ror:superpom-jfrog-artifactory`

 